### PR TITLE
Batch approval processing

### DIFF
--- a/coolNewLanguage/src/approvals/approvals.py
+++ b/coolNewLanguage/src/approvals/approvals.py
@@ -132,12 +132,23 @@ def handle_table_approve_result(table_approve_result: TableApproveResult):
     """
     # Filter the rows that were approved
     approved_rows = []
-    for index, _ in table_approve_result.dataframe.iterrows():
-        approve_result_name = f'approve_{table_approve_result.id}_{index}'
-        raw_approval_state = process.approval_post_body[approve_result_name]
-        approval_state = ApproveState.of_string(raw_approval_state)
-        if approval_state == ApproveState.APPROVED:
-            approved_rows.append(index)
+
+    # Check which batch option was checked
+    approve_batch = f'approve_{table_approve_result.id}_batch'
+    raw_batch_state = process.approval_post_body[approve_batch]
+    approval_state = ApproveState.of_string(raw_batch_state)
+    # If batch approve, then add all indexes to approved_rows
+    if approval_state == ApproveState.APPROVED:
+        approved_rows = [index for index, _ in table_approve_result.dataframe.iterrows()]
+
+    # Otherwise, check row individually.
+    else:
+        for index, _ in table_approve_result.dataframe.iterrows():
+            approve_result_name = f'approve_{table_approve_result.id}_{index}'
+            raw_approval_state = process.approval_post_body[approve_result_name]
+            approval_state = ApproveState.of_string(raw_approval_state)
+            if approval_state == ApproveState.APPROVED:
+                approved_rows.append(index)
 
     # If there were no approved rows, then return early
     if len(approved_rows) == 0:

--- a/coolNewLanguage/src/approvals/approvals.py
+++ b/coolNewLanguage/src/approvals/approvals.py
@@ -133,22 +133,12 @@ def handle_table_approve_result(table_approve_result: TableApproveResult):
     # Filter the rows that were approved
     approved_rows = []
 
-    # Check which batch option was checked
-    approve_batch = f'approve_{table_approve_result.id}_batch'
-    raw_batch_state = process.approval_post_body[approve_batch]
-    approval_state = ApproveState.of_string(raw_batch_state)
-    # If batch approve, then add all indexes to approved_rows
-    if approval_state == ApproveState.APPROVED:
-        approved_rows = [index for index, _ in table_approve_result.dataframe.iterrows()]
-
-    # Otherwise, check row individually.
-    else:
-        for index, _ in table_approve_result.dataframe.iterrows():
-            approve_result_name = f'approve_{table_approve_result.id}_{index}'
-            raw_approval_state = process.approval_post_body[approve_result_name]
-            approval_state = ApproveState.of_string(raw_approval_state)
-            if approval_state == ApproveState.APPROVED:
-                approved_rows.append(index)
+    for index, _ in table_approve_result.dataframe.iterrows():
+        approve_result_name = f'approve_{table_approve_result.id}_{index}'
+        raw_approval_state = process.approval_post_body[approve_result_name]
+        approval_state = ApproveState.of_string(raw_approval_state)
+        if approval_state == ApproveState.APPROVED:
+            approved_rows.append(index)
 
     # If there were no approved rows, then return early
     if len(approved_rows) == 0:

--- a/coolNewLanguage/src/approvals/approve_state.py
+++ b/coolNewLanguage/src/approvals/approve_state.py
@@ -5,6 +5,7 @@ class ApproveState(Enum):
     PENDING = auto()
     APPROVED = auto()
     REJECTED = auto()
+    IGNORE = auto()
 
     @staticmethod
     def of_string(s: str):
@@ -14,4 +15,6 @@ class ApproveState(Enum):
             return ApproveState.REJECTED
         elif s == "pending":
             return ApproveState.PENDING
+        elif s == "ignore":
+            return ApproveState.IGNORE
         raise ValueError("Unrecognized ApproveState string: " + s)

--- a/coolNewLanguage/src/stage/results.py
+++ b/coolNewLanguage/src/stage/results.py
@@ -123,7 +123,7 @@ def result_template_of_value(value) -> str:
             try:
                 return result_template_of_dataframe(process.running_tool.tables[table_name])
             except:
-                return "Table " + table_name + " not found. May be caused by user rejecting all rows or leaving all rows pending during table creation, thus resulting the table not being created."
+                return f"Table \"{table_name}\" not found, possibly because all its rows were rejected or left pending, resulting in the table not being created."
         case pd.DataFrame():
             return result_template_of_dataframe(value)
         case _:

--- a/coolNewLanguage/src/stage/results.py
+++ b/coolNewLanguage/src/stage/results.py
@@ -120,7 +120,10 @@ def result_template_of_value(value) -> str:
         case [*links] if all(isinstance(l, Link) for l in links):
             return "\n".join(result_template_of_link(l) for l in links)
         case pd.DataFrame(name=table_name):
-            return result_template_of_dataframe(process.running_tool.tables[table_name])
+            try:
+                return result_template_of_dataframe(process.running_tool.tables[table_name])
+            except:
+                return "Table " + table_name + " not found. May be caused by user rejecting all rows during table creation, thus resulting the table not being created."
         case pd.DataFrame():
             return result_template_of_dataframe(value)
         case _:

--- a/coolNewLanguage/src/stage/results.py
+++ b/coolNewLanguage/src/stage/results.py
@@ -123,7 +123,7 @@ def result_template_of_value(value) -> str:
             try:
                 return result_template_of_dataframe(process.running_tool.tables[table_name])
             except:
-                return "Table " + table_name + " not found. May be caused by user rejecting all rows during table creation, thus resulting the table not being created."
+                return "Table " + table_name + " not found. May be caused by user rejecting all rows or leaving all rows pending during table creation, thus resulting the table not being created."
         case pd.DataFrame():
             return result_template_of_dataframe(value)
         case _:

--- a/coolNewLanguage/web/static/approvals.js
+++ b/coolNewLanguage/web/static/approvals.js
@@ -1,0 +1,18 @@
+function handleRadioControl() {
+    const approveAllRadio = document.getElementById('approveAll');
+    const manualRadio = document.getElementById('manualSelection');
+
+    if (approveAllRadio.checked) {
+        // Shift all radio buttons to approve
+        const allApproveRadios = document.querySelectorAll(
+            'input[type="radio"][value="approve"]'
+        );
+        allApproveRadios.forEach(radio => { radio.checked = true });
+    } else if (manualRadio.checked) {
+        // Shift all radio buttons to pending
+        const allPendingRadios = document.querySelectorAll(
+            'input[type="radio"][value="pending"]'
+        );
+        allPendingRadios.forEach(radio => { radio.checked = true });
+    }
+}

--- a/coolNewLanguage/web/static/approvals.js
+++ b/coolNewLanguage/web/static/approvals.js
@@ -1,5 +1,6 @@
 function handleRadioControl() {
     const approveAllRadio = document.getElementById('approveAll');
+    const rejectAllRadio = document.getElementById('rejectAll');
     const manualRadio = document.getElementById('manualSelection');
 
     if (approveAllRadio.checked) {
@@ -8,6 +9,12 @@ function handleRadioControl() {
             'input[type="radio"][value="approve"]'
         );
         allApproveRadios.forEach(radio => { radio.checked = true });
+    } else if (rejectAllRadio.checked) {
+        // Shift all radio buttons to reject
+        const allRejectRadios = document.querySelectorAll(
+            'input[type="radio"][value="reject"]'
+        );
+        allRejectRadios.forEach(radio => { radio.checked = true });
     } else if (manualRadio.checked) {
         // Shift all radio buttons to pending
         const allPendingRadios = document.querySelectorAll(

--- a/coolNewLanguage/web/templates/approval_page.html
+++ b/coolNewLanguage/web/templates/approval_page.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>Approvals for {{ stage_name }}</title>
+    <script src="/static/approvals.js" async></script>
 </head>
 <body>
     <form action="{{ form_action }}" method="{{ form_method }}" enctype="{{  form_enctype }}">
@@ -52,12 +53,12 @@
         <h3>
             <label>
                 Approve all
-                <input type="radio" name="approve_{{ approve_result.id }}_batch" id="selectAll">
+                <input type="radio" name="approve_{{ approve_result.id }}_batch" id="approveAll" onchange="handleRadioControl()">
             </label>
             <br>
             <label>
                 Manual selection
-                <input type="radio" name="approve_{{ approve_result.id }}_batch" id="manualSelection" checked>
+                <input type="radio" name="approve_{{ approve_result.id }}_batch" id="manualSelection" checked onchange="handleRadioControl()">
             </label>
         </h3>
         <table>
@@ -98,34 +99,6 @@
                 </tr>
                 {% endfor %}
             </tbody>
-            <script>
-            // Function to handle batch radio button selection
-            function handleRadioControl() {
-                const selectAllRadio = document.getElementById('selectAll');
-                const manualRadio = document.getElementById('manualSelection');
-                const allRadios = document.querySelectorAll('input[type="radio"].input');
-
-                if (selectAllRadio.checked) {
-                    // Select all radio buttons
-                    allRadios.forEach(radio => {
-                        if (radio.value === "approve") {
-                    	radio.checked = true;
-                    }
-                    });
-                } else if (manualRadio.checked) {
-                    // Shift all radio buttons to pending
-                    allRadios.forEach(radio => {
-                	    if (radio.value === "pending") {
-                    	radio.checked = true;
-                    }
-                    });
-            }
-        }
-
-        // Add event listeners to control radio buttons
-        document.getElementById('selectAll').addEventListener('change', handleRadioControl);
-        document.getElementById('manualSelection').addEventListener('change', handleRadioControl);
-    </script>
         </table>
     </div>
     {% elif approve_result.approve_result_type == ApproveResultType.ROW %}

--- a/coolNewLanguage/web/templates/approval_page.html
+++ b/coolNewLanguage/web/templates/approval_page.html
@@ -57,7 +57,12 @@
             </label>
             <br>
             <label>
-                Manual selection
+                Reject all
+                <input type="radio" name="approve_{{ approve_result.id }}_batch" id="rejectAll" onchange="handleRadioControl()">
+            </label>
+            <br>
+            <label>
+                Set all to pending
                 <input type="radio" name="approve_{{ approve_result.id }}_batch" id="manualSelection" checked onchange="handleRadioControl()">
             </label>
         </h3>

--- a/coolNewLanguage/web/templates/approval_page.html
+++ b/coolNewLanguage/web/templates/approval_page.html
@@ -48,6 +48,18 @@
     {% elif approve_result.approve_result_type == ApproveResultType.TABLE %}
     <div>
         <h1>Select rows to approve for {{ approve_result.table_name }}</h1>
+        <h2> Batch operations: </h2>
+        <h3>
+            <label>
+                Approve all
+                <input type="radio" name="approve_{{ approve_result.id }}_batch" value="approve">
+            </label>
+            <br>
+            <label>
+                Manual selection
+                <input type="radio" name="approve_{{ approve_result.id }}_batch" value="ignore" checked>
+            </label>
+        </h3>
         <table>
             <thead>
                 <tr>

--- a/coolNewLanguage/web/templates/approval_page.html
+++ b/coolNewLanguage/web/templates/approval_page.html
@@ -52,12 +52,12 @@
         <h3>
             <label>
                 Approve all
-                <input type="radio" name="approve_{{ approve_result.id }}_batch" value="approve">
+                <input type="radio" name="approve_{{ approve_result.id }}_batch" id="selectAll">
             </label>
             <br>
             <label>
                 Manual selection
-                <input type="radio" name="approve_{{ approve_result.id }}_batch" value="ignore" checked>
+                <input type="radio" name="approve_{{ approve_result.id }}_batch" id="manualSelection" checked>
             </label>
         </h3>
         <table>
@@ -77,19 +77,19 @@
                     <td>
                         <label>
                             ✓
-                            <input type="radio" name="approve_{{ approve_result.id }}_{{ index }}" value="approve">
+                            <input type="radio" name="approve_{{ approve_result.id }}_{{ index }}" class="input" value="approve">
                         </label>
                     </td>
                     <td>
                         <label>
                             ✘
-                            <input type="radio" name="approve_{{ approve_result.id }}_{{ index }}" value="reject">
+                            <input type="radio" name="approve_{{ approve_result.id }}_{{ index }}" class="input" value="reject">
                         </label>
                     </td>
                     <td>
                         <label>
                             ?
-                            <input type="radio" name="approve_{{ approve_result.id }}_{{ index }}" value="pending" checked>
+                            <input type="radio" name="approve_{{ approve_result.id }}_{{ index }}" class="input" value="pending" checked>
                         </label>
                     </td>
                     {% for column_name in approve_result.column_names %}
@@ -98,6 +98,34 @@
                 </tr>
                 {% endfor %}
             </tbody>
+            <script>
+            // Function to handle batch radio button selection
+            function handleRadioControl() {
+                const selectAllRadio = document.getElementById('selectAll');
+                const manualRadio = document.getElementById('manualSelection');
+                const allRadios = document.querySelectorAll('input[type="radio"].input');
+
+                if (selectAllRadio.checked) {
+                    // Select all radio buttons
+                    allRadios.forEach(radio => {
+                        if (radio.value === "approve") {
+                    	radio.checked = true;
+                    }
+                    });
+                } else if (manualRadio.checked) {
+                    // Shift all radio buttons to pending
+                    allRadios.forEach(radio => {
+                	    if (radio.value === "pending") {
+                    	radio.checked = true;
+                    }
+                    });
+            }
+        }
+
+        // Add event listeners to control radio buttons
+        document.getElementById('selectAll').addEventListener('change', handleRadioControl);
+        document.getElementById('manualSelection').addEventListener('change', handleRadioControl);
+    </script>
         </table>
     </div>
     {% elif approve_result.approve_result_type == ApproveResultType.ROW %}


### PR DESCRIPTION
Create batch approval processing. Adds an option for the user to approval all entries for a TableApproveResult. If the user decides manually select (the default option), each row is processed individually as previously implemented.